### PR TITLE
prevent a syscall failure when waiting on a child process on osx

### DIFF
--- a/testing.h
+++ b/testing.h
@@ -362,7 +362,13 @@ static void testExecute( TestRunner run ) {
             testInternalError();
 
         int status = 0;
+#if defined(__APPLE__)
+        do {
+            r = waitpid( pid, &status, 0 );
+        } while (r == -1 && errno == EINTR);
+#else
         r = waitpid( pid, &status, 0 );
+#endif
         if ( r == -1 )
             testInternalError();
 


### PR DESCRIPTION
When used in combination with Debugger (LLDB) in CLion on osx, the library fails when waiting for a child process's pid. This fixes the issue.